### PR TITLE
fix(taskfile): resolve STAGE from .env in cf tasks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOLANG_VERSION: 1.25.9
+  GOLANG_VERSION: 1.25.10
 
 permissions:
   contents: read
@@ -63,7 +63,7 @@ jobs:
     if: github.event_name == 'push' || needs.check-label.outputs.should-run == 'true'
     strategy:
       matrix:
-        go-version: ["1.25.9"]
+        go-version: ["1.25.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     if: always() && !cancelled() && (needs.build.result == 'success' && needs.lint.result == 'success')
     strategy:
       matrix:
-        go-version: ["1.25.9"]
+        go-version: ["1.25.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,7 +99,8 @@ tasks:
     dotenv: ['.env']
     deps: [build:lambda]
     vars:
-      STAGE: '{{.STAGE | default "dev"}}'
+      STAGE:
+        sh: 'if [ -z "${STAGE-}" ] && [ -f .env ]; then set -a && . ./.env && set +a; fi; echo "${STAGE:-dev}"'
       REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - zip -j {{.LAMBDA_ZIP}} {{.LAMBDA_BINARY}}
@@ -121,7 +122,8 @@ tasks:
     dotenv: ['.env']
     deps: [cf:package]
     vars:
-      STAGE: '{{.STAGE | default "dev"}}'
+      STAGE:
+        sh: 'if [ -z "${STAGE-}" ] && [ -f .env ]; then set -a && . ./.env && set +a; fi; echo "${STAGE:-dev}"'
       REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - |
@@ -145,7 +147,8 @@ tasks:
     desc: Delete the CloudFormation stack (backup bucket is retained)
     dotenv: ['.env']
     vars:
-      STAGE: '{{.STAGE | default "dev"}}'
+      STAGE:
+        sh: 'if [ -z "${STAGE-}" ] && [ -f .env ]; then set -a && . ./.env && set +a; fi; echo "${STAGE:-dev}"'
       REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - aws cloudformation delete-stack --stack-name {{.STACK_PREFIX}}-{{.STAGE}} --region {{.REGION}}
@@ -156,7 +159,8 @@ tasks:
     desc: Tail CloudWatch logs for the Lambda
     dotenv: ['.env']
     vars:
-      STAGE: '{{.STAGE | default "dev"}}'
+      STAGE:
+        sh: 'if [ -z "${STAGE-}" ] && [ -f .env ]; then set -a && . ./.env && set +a; fi; echo "${STAGE:-dev}"'
       REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - aws logs tail /aws/lambda/{{.STACK_PREFIX}}-{{.STAGE}} --follow --region {{.REGION}}
@@ -165,7 +169,8 @@ tasks:
     desc: Manually invoke the backup Lambda
     dotenv: ['.env']
     vars:
-      STAGE: '{{.STAGE | default "dev"}}'
+      STAGE:
+        sh: 'if [ -z "${STAGE-}" ] && [ -f .env ]; then set -a && . ./.env && set +a; fi; echo "${STAGE:-dev}"'
       REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - aws lambda invoke --function-name {{.STACK_PREFIX}}-{{.STAGE}} --region {{.REGION}} /tmp/invoke-out.json


### PR DESCRIPTION
## Summary
- The `cf:*` tasks default `STAGE` to `dev` only when `STAGE` is unset in the environment, ignoring any `STAGE` defined in `.env`.
- Source `.env` (when `STAGE` isn't already set in the environment) before defaulting, so `cf:package`, `cf:deploy`, `cf:remove`, `cf:logs`, and `cf:invoke` all target the stage configured in `.env`.

## Test plan
- `STAGE=prod task cf:deploy` → uses `prod` (env takes precedence)
- `.env` with `STAGE=staging`, no env var → uses `staging`
- neither set → falls back to `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)