### PR TITLE
chore: awesome-go compliance (release pipeline, testable package, ~93% coverage)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,6 +120,12 @@ jobs:
       - name: Run tests with coverage
         run: task test:coverage
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: bootstrap
+    main: ./cmd/lambda/
+    # AWS Lambda's provided.al2 runtime expects the handler binary to be
+    # named "bootstrap".
+    binary: bootstrap
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - arm64
+      - amd64
+    ldflags:
+      - -s -w -X "main.version={{.Version}}" -X "main.commit={{.Commit}}" -X "main.date={{.Date}}"
+
+archives:
+  - id: lambda
+    # Zip so the artifact can be uploaded straight to AWS Lambda; the arm64
+    # archive matches the deployed runtime (provided.al2, arm64).
+    formats:
+      - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![Backup Banner](shutdown.jpeg)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/nicobistolfi/go-postgres-s3-backup.svg)](https://pkg.go.dev/github.com/nicobistolfi/go-postgres-s3-backup)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nicobistolfi/go-postgres-s3-backup)](https://goreportcard.com/report/github.com/nicobistolfi/go-postgres-s3-backup)
+[![Build & Test](https://github.com/nicobistolfi/go-postgres-s3-backup/actions/workflows/go.yml/badge.svg)](https://github.com/nicobistolfi/go-postgres-s3-backup/actions/workflows/go.yml)
+[![codecov](https://codecov.io/gh/nicobistolfi/go-postgres-s3-backup/branch/main/graph/badge.svg)](https://codecov.io/gh/nicobistolfi/go-postgres-s3-backup)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A serverless backup solution for PostgreSQL databases using AWS Lambda, with automatic daily, monthly, and yearly backup rotation to S3.
 
 ## Features
@@ -14,28 +20,35 @@ A serverless backup solution for PostgreSQL databases using AWS Lambda, with aut
 - ✅ Yearly backups moved to Deep Archive for long-term retention
 - ✅ Deployed via AWS CloudFormation
 - ✅ S3 bucket encryption and versioning enabled
-- ✅ Uses pgx/v5 for efficient PostgreSQL connectivity
+- ✅ Content-aware deduplication via SHA-256 checksums
+- ✅ Reusable, documented `backup` package with ~90% test coverage
 
 ## Project Structure
 
 ```
 /
+├── backup/                   # Importable, documented backup library
+│   ├── backup.go             #   Handler, Config, Result, Run
+│   ├── store.go              #   S3API interface + storage helpers
+│   ├── dump.go               #   pg_dump invocation
+│   ├── database.go           #   DATABASE_URL parsing
+│   ├── events.go             #   Lambda dispatch + /run HTTP auth
+│   └── size.go               #   human-readable sizes
 ├── cmd/
 │   └── lambda/
-│       └── main.go           # Lambda function entry point
+│       └── main.go           # Lambda entry point (thin wiring)
 ├── cloudformation/
 │   └── template.yml          # CloudFormation stack definition
 ├── postgres-layer/           # Lambda layer with pg_dump/psql
+├── .goreleaser.yml           # Release build configuration
 ├── Taskfile.yml              # Task runner configuration
-├── .env                      # Environment variables (not in repo)
-├── .gitignore                # Git ignore file
 ├── go.mod                    # Go module file
 └── README.md                 # This file
 ```
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.24+
 - [Task](https://taskfile.dev)
 - Docker (for building the PostgreSQL layer)
 - AWS CLI configured

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -1,0 +1,169 @@
+// Package backup creates PostgreSQL dumps with pg_dump and stores them in S3
+// on a daily/monthly/yearly rotation. It deduplicates unchanged dumps by
+// SHA-256, prunes daily backups past a retention window, and can be driven
+// either on a schedule or on demand through an authenticated HTTP endpoint.
+package backup
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// Dumper produces a SQL dump of the given database. The default implementation
+// is PgDump; tests inject their own.
+type Dumper func(ctx context.Context, db DatabaseConfig) ([]byte, error)
+
+// Config configures a Handler.
+type Config struct {
+	S3            S3API          // S3 client (required)
+	Bucket        string         // destination bucket (required)
+	Database      DatabaseConfig // database to dump (required)
+	RetentionDays int            // daily backups to keep; <= 0 means 7
+	Dump          Dumper         // dump implementation; nil means PgDump
+}
+
+// Handler runs backups against a bucket and database.
+type Handler struct {
+	s3            S3API
+	bucket        string
+	db            DatabaseConfig
+	retentionDays int
+	dump          Dumper
+	now           func() time.Time
+}
+
+// New builds a Handler from cfg, applying defaults for RetentionDays (7) and
+// Dump (PgDump).
+func New(cfg Config) *Handler {
+	dump := cfg.Dump
+	if dump == nil {
+		dump = PgDump
+	}
+	retention := cfg.RetentionDays
+	if retention <= 0 {
+		retention = 7
+	}
+	return &Handler{
+		s3:            cfg.S3,
+		bucket:        cfg.Bucket,
+		db:            cfg.Database,
+		retentionDays: retention,
+		dump:          dump,
+		now:           time.Now,
+	}
+}
+
+// Result summarizes a single backup run.
+type Result struct {
+	Status     string `json:"status"`      // always "ok" on success
+	Action     string `json:"action"`      // "created" or "skipped"
+	Reason     string `json:"reason"`      // why the daily backup was created/skipped
+	Key        string `json:"key"`         // today's daily backup S3 key
+	Size       string `json:"size"`        // human-readable dump size (e.g. "12.34 MB")
+	SizeBytes  int    `json:"size_bytes"`  // size of the dump in bytes
+	DurationMs int64  `json:"duration_ms"` // wall-clock time of the run
+}
+
+// Run produces a dump and stores it. A normal run stores the daily backup only
+// when the dump differs from the most recent daily backup. When force is true
+// (a manual invocation) it stores today's backup even if it matches an older
+// one, but still skips rewriting today's file when that file is already
+// identical. Monthly and yearly backups are created when missing, and daily
+// backups older than the retention window are pruned.
+func (h *Handler) Run(ctx context.Context, force bool) (*Result, error) {
+	start := h.now()
+	log.Println("Starting database backup...")
+
+	raw, err := h.dump(ctx, h.db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create backup: %w", err)
+	}
+	data := removeTimestampComments(raw)
+	sum := checksum(data)
+	log.Printf("Backup created, size: %d bytes", len(data))
+
+	now := h.now()
+	dailyKey := fmt.Sprintf("daily/%s-backup.sql", now.Format("2006-01-02"))
+	result := &Result{
+		Status:    "ok",
+		Key:       dailyKey,
+		Size:      HumanizeSize(len(data)),
+		SizeBytes: len(data),
+	}
+
+	upload, reason := h.decideDailyUpload(ctx, dailyKey, sum, force)
+	result.Reason = reason
+	if !upload {
+		log.Printf("Skipping daily backup upload: %s", reason)
+		result.Action = "skipped"
+		result.DurationMs = h.elapsed(start)
+		return result, nil
+	}
+
+	if err := h.upload(ctx, dailyKey, data, sum); err != nil {
+		return nil, fmt.Errorf("failed to upload daily backup: %w", err)
+	}
+	log.Printf("Daily backup uploaded: %s", dailyKey)
+	result.Action = "created"
+
+	if err := h.createPeriodicBackups(ctx, now, data, sum); err != nil {
+		return nil, err
+	}
+
+	if err := h.cleanupOldDailyBackups(ctx); err != nil {
+		log.Printf("Warning: failed to clean up old daily backups: %v", err)
+	}
+
+	log.Println("Backup process completed successfully")
+	result.DurationMs = h.elapsed(start)
+	return result, nil
+}
+
+// decideDailyUpload determines whether today's daily backup should be written
+// and why. A normal run stores it only when the dump differs from the most
+// recent daily backup; a forced run stores it unless today's file is already
+// identical.
+func (h *Handler) decideDailyUpload(ctx context.Context, dailyKey, sum string, force bool) (upload bool, reason string) {
+	mostRecent, err := h.mostRecentBackup(ctx, "daily/")
+	if err != nil {
+		log.Printf("Warning: couldn't find most recent backup: %v", err)
+	}
+
+	contentChanged := mostRecent == "" || !h.objectMatches(ctx, mostRecent, sum)
+	if contentChanged {
+		return true, "content changed"
+	}
+	switch {
+	case !force:
+		return false, "unchanged"
+	case h.objectMatches(ctx, dailyKey, sum):
+		return false, "today's backup already identical"
+	default:
+		return true, "forced; matched an older backup"
+	}
+}
+
+// createPeriodicBackups creates the monthly and yearly backups for now if they
+// do not already exist.
+func (h *Handler) createPeriodicBackups(ctx context.Context, now time.Time, data []byte, sum string) error {
+	monthlyKey := fmt.Sprintf("monthly/%s-backup.sql", now.Format("2006-01"))
+	if created, err := h.uploadIfMissing(ctx, monthlyKey, data, sum); err != nil {
+		return err
+	} else if created {
+		log.Printf("Monthly backup created: %s", monthlyKey)
+	}
+
+	yearlyKey := fmt.Sprintf("yearly/%s-backup.sql", now.Format("2006"))
+	if created, err := h.uploadIfMissing(ctx, yearlyKey, data, sum); err != nil {
+		return err
+	} else if created {
+		log.Printf("Yearly backup created: %s", yearlyKey)
+	}
+	return nil
+}
+
+func (h *Handler) elapsed(start time.Time) int64 {
+	return h.now().Sub(start).Milliseconds()
+}

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -1,0 +1,237 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+const testDate = "2026-05-27"
+
+var testNow = time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+func runHandler(t *testing.T, f *fakeS3, dump Dumper, retention int) *Handler {
+	t.Helper()
+	h := New(Config{
+		S3:            f,
+		Bucket:        "test-bucket",
+		Database:      DatabaseConfig{Host: "localhost"},
+		RetentionDays: retention,
+		Dump:          dump,
+	})
+	h.now = fixedClock(testNow)
+	return h
+}
+
+func TestRunCreatesAllBackups(t *testing.T) {
+	f := newFakeS3()
+	h := runHandler(t, f, staticDump([]byte("CREATE TABLE foo;")), 7)
+
+	res, err := h.Run(context.Background(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "created" || res.Reason != "content changed" {
+		t.Errorf("action=%q reason=%q, want created/content changed", res.Action, res.Reason)
+	}
+	if res.Status != "ok" || res.Key != "daily/"+testDate+"-backup.sql" {
+		t.Errorf("status=%q key=%q unexpected", res.Status, res.Key)
+	}
+	if res.SizeBytes == 0 || res.Size == "" {
+		t.Errorf("size not populated: size=%q bytes=%d", res.Size, res.SizeBytes)
+	}
+	for _, key := range []string{
+		"daily/" + testDate + "-backup.sql",
+		"monthly/2026-05-backup.sql",
+		"yearly/2026-backup.sql",
+	} {
+		if _, ok := f.objects[key]; !ok {
+			t.Errorf("expected object %q to be created", key)
+		}
+	}
+}
+
+func TestRunScheduledSkipsUnchanged(t *testing.T) {
+	body := []byte("unchanged")
+	f := newFakeS3()
+	// Seed today's daily with identical content as the most recent backup.
+	f.seed("daily/"+testDate+"-backup.sql", body, testNow.Add(-time.Hour))
+	h := runHandler(t, f, staticDump(body), 7)
+	before := f.puts
+
+	res, err := h.Run(context.Background(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "skipped" || res.Reason != "unchanged" {
+		t.Errorf("action=%q reason=%q, want skipped/unchanged", res.Action, res.Reason)
+	}
+	if f.puts != before {
+		t.Errorf("expected no uploads, got %d", f.puts-before)
+	}
+}
+
+func TestRunForcedStoresWhenTodayMissing(t *testing.T) {
+	body := []byte("same-as-old")
+	f := newFakeS3()
+	// An older day's backup matches, but today's key is absent.
+	f.seed("daily/2026-05-20-backup.sql", body, testNow.Add(-72*time.Hour))
+	h := runHandler(t, f, staticDump(body), 30)
+
+	res, err := h.Run(context.Background(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "created" || res.Reason != "forced; matched an older backup" {
+		t.Errorf("action=%q reason=%q, want created/forced", res.Action, res.Reason)
+	}
+	if _, ok := f.objects["daily/"+testDate+"-backup.sql"]; !ok {
+		t.Error("expected today's daily backup to be created")
+	}
+}
+
+func TestRunForcedSkipsWhenTodayIdentical(t *testing.T) {
+	body := []byte("identical-today")
+	f := newFakeS3()
+	f.seed("daily/"+testDate+"-backup.sql", body, testNow)
+	h := runHandler(t, f, staticDump(body), 7)
+	before := f.puts
+
+	res, err := h.Run(context.Background(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "skipped" || res.Reason != "today's backup already identical" {
+		t.Errorf("action=%q reason=%q, want skipped/identical", res.Action, res.Reason)
+	}
+	if f.puts != before {
+		t.Errorf("expected no uploads, got %d", f.puts-before)
+	}
+}
+
+func TestRunForcedContentChanged(t *testing.T) {
+	f := newFakeS3()
+	// Today's existing backup differs from the new dump.
+	f.seed("daily/"+testDate+"-backup.sql", []byte("old-content"), testNow.Add(-time.Hour))
+	h := runHandler(t, f, staticDump([]byte("new-content")), 7)
+
+	res, err := h.Run(context.Background(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "created" || res.Reason != "content changed" {
+		t.Errorf("action=%q reason=%q, want created/content changed", res.Action, res.Reason)
+	}
+}
+
+func TestRunDoesNotRecreatePeriodicBackups(t *testing.T) {
+	f := newFakeS3()
+	// Pre-existing monthly/yearly with distinct bodies must be preserved.
+	f.seed("monthly/2026-05-backup.sql", []byte("OLD-MONTHLY"), testNow.Add(-time.Hour))
+	f.seed("yearly/2026-backup.sql", []byte("OLD-YEARLY"), testNow.Add(-time.Hour))
+	h := runHandler(t, f, staticDump([]byte("fresh-daily")), 7)
+
+	if _, err := h.Run(context.Background(), false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := string(f.objects["monthly/2026-05-backup.sql"].body); got != "OLD-MONTHLY" {
+		t.Errorf("monthly backup overwritten: %q", got)
+	}
+	if got := string(f.objects["yearly/2026-backup.sql"].body); got != "OLD-YEARLY" {
+		t.Errorf("yearly backup overwritten: %q", got)
+	}
+}
+
+func TestRunCleansUpOldDailyBackups(t *testing.T) {
+	f := newFakeS3()
+	f.seed("daily/2026-05-01-backup.sql", []byte("old"), testNow.Add(-100*time.Hour))   // before cutoff -> deleted
+	f.seed("daily/2026-05-26-backup.sql", []byte("recent"), testNow.Add(-24*time.Hour)) // within window -> kept
+	f.seed("daily/not-a-date-backup.sql", []byte("weird"), testNow.Add(-24*time.Hour))  // unparseable -> kept
+	h := runHandler(t, f, staticDump([]byte("fresh")), 7)
+
+	if _, err := h.Run(context.Background(), false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := f.objects["daily/2026-05-01-backup.sql"]; ok {
+		t.Error("expected old daily backup to be deleted")
+	}
+	if _, ok := f.objects["daily/2026-05-26-backup.sql"]; !ok {
+		t.Error("expected recent daily backup to be kept")
+	}
+	if _, ok := f.objects["daily/not-a-date-backup.sql"]; !ok {
+		t.Error("expected unparseable key to be left untouched")
+	}
+}
+
+func TestRunDumpError(t *testing.T) {
+	h := runHandler(t, newFakeS3(), failingDump(errors.New("pg_dump exploded")), 7)
+	if _, err := h.Run(context.Background(), false); err == nil {
+		t.Fatal("expected error when dump fails, got nil")
+	}
+}
+
+func TestRunUploadError(t *testing.T) {
+	f := newFakeS3()
+	f.putErr = errors.New("S3 down")
+	h := runHandler(t, f, staticDump([]byte("data")), 7)
+	if _, err := h.Run(context.Background(), false); err == nil {
+		t.Fatal("expected error when upload fails, got nil")
+	}
+}
+
+func TestRunListErrorStillUploads(t *testing.T) {
+	f := newFakeS3()
+	f.listErr = errors.New("list failed")
+	h := runHandler(t, f, staticDump([]byte("data")), 7)
+
+	// A failing list is treated as "no prior backup", so the run proceeds.
+	res, err := h.Run(context.Background(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != "created" {
+		t.Errorf("action=%q, want created", res.Action)
+	}
+}
+
+func TestRunPeriodicCheckError(t *testing.T) {
+	f := newFakeS3()
+	// Empty bucket so the daily upload succeeds, but HeadObject fails when the
+	// monthly backup existence is checked.
+	f.headErr = errors.New("AccessDenied")
+	h := runHandler(t, f, staticDump([]byte("data")), 7)
+
+	if _, err := h.Run(context.Background(), false); err == nil {
+		t.Fatal("expected error from periodic backup check, got nil")
+	}
+}
+
+func TestRunCleanupDeleteErrorIsNonFatal(t *testing.T) {
+	f := newFakeS3()
+	f.seed("daily/2026-05-01-backup.sql", []byte("old"), testNow.Add(-100*time.Hour))
+	f.deleteErr = errors.New("delete denied")
+	h := runHandler(t, f, staticDump([]byte("fresh")), 7)
+
+	// A delete failure during cleanup is logged but must not fail the run.
+	res, err := h.Run(context.Background(), false)
+	if err != nil {
+		t.Fatalf("cleanup delete error should be non-fatal, got: %v", err)
+	}
+	if res.Action != "created" {
+		t.Errorf("action = %q, want created", res.Action)
+	}
+	if _, ok := f.objects["daily/2026-05-01-backup.sql"]; !ok {
+		t.Error("object should remain after failed delete")
+	}
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	h := New(Config{S3: newFakeS3(), Bucket: "b"})
+	if h.retentionDays != 7 {
+		t.Errorf("retentionDays = %d, want default 7", h.retentionDays)
+	}
+	if h.dump == nil {
+		t.Error("dump should default to PgDump, got nil")
+	}
+}

--- a/backup/database.go
+++ b/backup/database.go
@@ -1,0 +1,45 @@
+package backup
+
+import (
+	"net/url"
+	"strings"
+)
+
+// DatabaseConfig holds the connection parameters used to invoke pg_dump.
+type DatabaseConfig struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	Database string
+}
+
+// ParseDatabaseURL parses a PostgreSQL connection string (for example
+// "postgresql://user:pass@host:5432/dbname") into a DatabaseConfig. The port
+// defaults to 5432 and the database name defaults to "postgres" when absent.
+func ParseDatabaseURL(dbURL string) (DatabaseConfig, error) {
+	u, err := url.Parse(dbURL)
+	if err != nil {
+		return DatabaseConfig{}, err
+	}
+
+	password, _ := u.User.Password()
+
+	port := u.Port()
+	if port == "" {
+		port = "5432"
+	}
+
+	database := strings.TrimPrefix(u.Path, "/")
+	if database == "" {
+		database = "postgres"
+	}
+
+	return DatabaseConfig{
+		Host:     u.Hostname(),
+		Port:     port,
+		User:     u.User.Username(),
+		Password: password,
+		Database: database,
+	}, nil
+}

--- a/backup/database_test.go
+++ b/backup/database_test.go
@@ -1,0 +1,45 @@
+package backup
+
+import "testing"
+
+func TestParseDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want DatabaseConfig
+	}{
+		{
+			name: "full",
+			url:  "postgresql://alice:secret@db.example.com:6543/shop",
+			want: DatabaseConfig{Host: "db.example.com", Port: "6543", User: "alice", Password: "secret", Database: "shop"},
+		},
+		{
+			name: "default port and database",
+			url:  "postgresql://bob@localhost/",
+			want: DatabaseConfig{Host: "localhost", Port: "5432", User: "bob", Password: "", Database: "postgres"},
+		},
+		{
+			name: "no user info",
+			url:  "postgres://example.org:5432/mydb",
+			want: DatabaseConfig{Host: "example.org", Port: "5432", User: "", Password: "", Database: "mydb"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDatabaseURL(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseDatabaseURL(%q) = %+v, want %+v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDatabaseURLError(t *testing.T) {
+	if _, err := ParseDatabaseURL("postgres://%zz"); err == nil {
+		t.Fatal("expected error for malformed URL, got nil")
+	}
+}

--- a/backup/dump.go
+++ b/backup/dump.go
@@ -1,0 +1,72 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+// PgDump produces a SQL dump of the given database by invoking the pg_dump
+// binary. It is the default Dumper used by New. On AWS Lambda the binary ships
+// in a layer mounted at /opt/opt/bin; elsewhere it is resolved from PATH.
+func PgDump(ctx context.Context, db DatabaseConfig) ([]byte, error) {
+	// The PostgreSQL layer mounts its tools under /opt/opt on Lambda.
+	_ = os.Setenv("PATH", "/opt/opt/bin:"+os.Getenv("PATH"))
+	_ = os.Setenv("LD_LIBRARY_PATH", "/opt/opt/lib:"+os.Getenv("LD_LIBRARY_PATH"))
+	_ = os.Setenv("PGPASSWORD", db.Password)
+
+	pgDumpPath := "/opt/opt/bin/pg_dump"
+	if _, err := os.Stat(pgDumpPath); os.IsNotExist(err) {
+		var lookupErr error
+		pgDumpPath, lookupErr = exec.LookPath("pg_dump")
+		if lookupErr != nil {
+			return nil, fmt.Errorf("pg_dump binary not found in /opt/opt/bin or PATH: %w", lookupErr)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, pgDumpPath,
+		"-h", db.Host,
+		"-p", db.Port,
+		"-U", db.User,
+		"-d", db.Database,
+		"--verbose",
+		"--no-owner",
+		"--no-privileges",
+		"--clean",
+		"--if-exists",
+		"--exclude-schema=supabase_migrations",
+		"--no-comments",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	log.Println("Executing pg_dump...")
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("pg_dump failed: %w\nstderr: %s", err, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		log.Printf("pg_dump stderr: %s", stderr.String())
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// removeTimestampComments strips the "-- Started on" / "-- Completed on" lines
+// pg_dump emits, which otherwise make byte-identical dumps appear to differ.
+func removeTimestampComments(data []byte) []byte {
+	lines := bytes.Split(data, []byte("\n"))
+	filtered := lines[:0]
+	for _, line := range lines {
+		if bytes.HasPrefix(line, []byte("-- Started on ")) ||
+			bytes.HasPrefix(line, []byte("-- Completed on ")) {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return bytes.Join(filtered, []byte("\n"))
+}

--- a/backup/dump_pgdump_test.go
+++ b/backup/dump_pgdump_test.go
@@ -1,0 +1,17 @@
+package backup
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPgDumpBinaryNotFound(t *testing.T) {
+	// Point PATH at a directory with no pg_dump so the lookup fails
+	// deterministically regardless of what's installed on the host.
+	t.Setenv("PATH", "/nonexistent-dir-for-test")
+
+	_, err := PgDump(context.Background(), DatabaseConfig{Host: "localhost", Database: "x"})
+	if err == nil {
+		t.Fatal("expected error when pg_dump is not found, got nil")
+	}
+}

--- a/backup/dump_test.go
+++ b/backup/dump_test.go
@@ -1,0 +1,22 @@
+package backup
+
+import "testing"
+
+func TestRemoveTimestampComments(t *testing.T) {
+	in := []byte("-- Started on 2026-05-27 10:00:00\n" +
+		"CREATE TABLE foo (id int);\n" +
+		"-- Completed on 2026-05-27 10:00:01\n" +
+		"INSERT INTO foo VALUES (1);")
+	want := "CREATE TABLE foo (id int);\nINSERT INTO foo VALUES (1);"
+
+	if got := string(removeTimestampComments(in)); got != want {
+		t.Errorf("removeTimestampComments() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTimestampCommentsNoComments(t *testing.T) {
+	in := []byte("line one\nline two")
+	if got := string(removeTimestampComments(in)); got != "line one\nline two" {
+		t.Errorf("removeTimestampComments() altered content without timestamps: %q", got)
+	}
+}

--- a/backup/events.go
+++ b/backup/events.go
@@ -1,0 +1,82 @@
+package backup
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"log"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// EventHandler adapts a Handler to AWS Lambda invocations: EventBridge
+// schedules (and direct invokes) run a deduplicated backup, while API Gateway
+// v2 HTTP requests to /run run an authenticated, forced backup.
+type EventHandler struct {
+	handler *Handler
+	apiKey  string
+}
+
+// NewEventHandler wraps h, authenticating HTTP requests against apiKey.
+func NewEventHandler(h *Handler, apiKey string) *EventHandler {
+	return &EventHandler{handler: h, apiKey: apiKey}
+}
+
+// Dispatch routes a raw Lambda event to the HTTP handler when it is an API
+// Gateway v2 request, or to a scheduled (deduplicated) backup otherwise.
+func (e *EventHandler) Dispatch(ctx context.Context, raw json.RawMessage) (any, error) {
+	var req events.APIGatewayV2HTTPRequest
+	if err := json.Unmarshal(raw, &req); err == nil && req.RequestContext.HTTP.Method != "" {
+		return e.handleHTTP(ctx, req), nil
+	}
+
+	// Scheduled or direct invocation: no HTTP response expected, dedupe applies.
+	_, err := e.handler.Run(ctx, false)
+	return nil, err
+}
+
+// handleHTTP authenticates the request, runs a forced backup, and returns an
+// HTTP response. It never returns an error so failures surface as HTTP status
+// codes rather than Lambda errors.
+func (e *EventHandler) handleHTTP(ctx context.Context, req events.APIGatewayV2HTTPRequest) events.APIGatewayV2HTTPResponse {
+	if !e.authorized(req) {
+		return jsonResponse(401, map[string]string{"status": "error", "error": "unauthorized"})
+	}
+
+	result, err := e.handler.Run(ctx, true)
+	if err != nil {
+		log.Printf("backup failed: %v", err)
+		return jsonResponse(500, map[string]string{"status": "error", "error": err.Error()})
+	}
+	return jsonResponse(200, result)
+}
+
+// authorized reports whether the request carries the configured API key, via
+// the X-Api-Key header or the api_key query string parameter.
+func (e *EventHandler) authorized(req events.APIGatewayV2HTTPRequest) bool {
+	if e.apiKey == "" {
+		log.Println("API key not configured; rejecting request")
+		return false
+	}
+	// API Gateway v2 lower-cases header names.
+	if provided, ok := req.Headers["x-api-key"]; ok && constantTimeEqual(provided, e.apiKey) {
+		return true
+	}
+	if provided, ok := req.QueryStringParameters["api_key"]; ok && constantTimeEqual(provided, e.apiKey) {
+		return true
+	}
+	return false
+}
+
+func constantTimeEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func jsonResponse(status int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: status,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}

--- a/backup/events_test.go
+++ b/backup/events_test.go
@@ -1,0 +1,123 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func eventHandler(f *fakeS3, apiKey string, dump Dumper) *EventHandler {
+	h := New(Config{S3: f, Bucket: "b", Dump: dump})
+	h.now = fixedClock(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC))
+	return NewEventHandler(h, apiKey)
+}
+
+func httpRequest(headers, query map[string]string) events.APIGatewayV2HTTPRequest {
+	req := events.APIGatewayV2HTTPRequest{
+		Headers:               headers,
+		QueryStringParameters: query,
+	}
+	req.RequestContext.HTTP.Method = "GET"
+	return req
+}
+
+func TestAuthorized(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiKey  string
+		headers map[string]string
+		query   map[string]string
+		want    bool
+	}{
+		{"no key configured", "", map[string]string{"x-api-key": "secret"}, nil, false},
+		{"header match", "secret", map[string]string{"x-api-key": "secret"}, nil, true},
+		{"header wrong", "secret", map[string]string{"x-api-key": "nope"}, nil, false},
+		{"query match", "secret", nil, map[string]string{"api_key": "secret"}, true},
+		{"query wrong", "secret", nil, map[string]string{"api_key": "nope"}, false},
+		{"neither", "secret", nil, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := eventHandler(newFakeS3(), tt.apiKey, staticDump([]byte("x")))
+			if got := e.authorized(httpRequest(tt.headers, tt.query)); got != tt.want {
+				t.Errorf("authorized = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchHTTPSuccess(t *testing.T) {
+	f := newFakeS3()
+	e := eventHandler(f, "secret", staticDump([]byte("data")))
+	raw, _ := json.Marshal(httpRequest(map[string]string{"x-api-key": "secret"}, nil))
+
+	out, err := e.Dispatch(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := out.(events.APIGatewayV2HTTPResponse)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(resp.Body, `"status":"ok"`) {
+		t.Errorf("body missing ok status: %s", resp.Body)
+	}
+}
+
+func TestDispatchHTTPUnauthorized(t *testing.T) {
+	e := eventHandler(newFakeS3(), "secret", staticDump([]byte("data")))
+	raw, _ := json.Marshal(httpRequest(map[string]string{"x-api-key": "wrong"}, nil))
+
+	out, _ := e.Dispatch(context.Background(), raw)
+	resp := out.(events.APIGatewayV2HTTPResponse)
+	if resp.StatusCode != 401 {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestDispatchHTTPBackupError(t *testing.T) {
+	e := eventHandler(newFakeS3(), "secret", failingDump(errors.New("boom")))
+	raw, _ := json.Marshal(httpRequest(map[string]string{"x-api-key": "secret"}, nil))
+
+	out, _ := e.Dispatch(context.Background(), raw)
+	resp := out.(events.APIGatewayV2HTTPResponse)
+	if resp.StatusCode != 500 {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestDispatchScheduled(t *testing.T) {
+	f := newFakeS3()
+	e := eventHandler(f, "secret", staticDump([]byte("scheduled-data")))
+	// An EventBridge-style payload has no RequestContext.HTTP.Method.
+	raw := json.RawMessage(`{"source":"aws.events","detail-type":"Scheduled Event"}`)
+
+	out, err := e.Dispatch(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("scheduled dispatch should return nil response, got %v", out)
+	}
+	if _, ok := f.objects["daily/2026-05-27-backup.sql"]; !ok {
+		t.Error("expected scheduled run to create a daily backup")
+	}
+}
+
+func TestJSONResponse(t *testing.T) {
+	resp := jsonResponse(201, map[string]string{"hello": "world"})
+	if resp.StatusCode != 201 {
+		t.Errorf("status = %d, want 201", resp.StatusCode)
+	}
+	if resp.Headers["Content-Type"] != "application/json" {
+		t.Errorf("content-type = %q", resp.Headers["Content-Type"])
+	}
+	if resp.Body != `{"hello":"world"}` {
+		t.Errorf("body = %q", resp.Body)
+	}
+}

--- a/backup/fakes_test.go
+++ b/backup/fakes_test.go
@@ -1,0 +1,138 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// fakeObject is an in-memory S3 object.
+type fakeObject struct {
+	body     []byte
+	metadata map[string]string
+	modified time.Time
+}
+
+// fakeS3 is an in-memory implementation of S3API for tests.
+type fakeS3 struct {
+	objects map[string]*fakeObject
+	clock   time.Time
+	puts    int // number of successful PutObject calls
+
+	// error injection
+	listErr   error
+	putErr    error
+	deleteErr error
+	headErr   error
+	getErr    error
+}
+
+func newFakeS3() *fakeS3 {
+	return &fakeS3{
+		objects: map[string]*fakeObject{},
+		clock:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// seed stores an object with its sha256 recorded in metadata.
+func (f *fakeS3) seed(key string, body []byte, modified time.Time) {
+	f.objects[key] = &fakeObject{
+		body:     body,
+		metadata: map[string]string{"sha256": checksum(body)},
+		modified: modified,
+	}
+}
+
+func (f *fakeS3) HeadObject(_ context.Context, params *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if f.headErr != nil {
+		return nil, f.headErr
+	}
+	obj, ok := f.objects[*params.Key]
+	if !ok {
+		return nil, fmt.Errorf("NotFound: %s", *params.Key)
+	}
+	return &s3.HeadObjectOutput{Metadata: obj.metadata}, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, params *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	obj, ok := f.objects[*params.Key]
+	if !ok {
+		return nil, fmt.Errorf("NoSuchKey: %s", *params.Key)
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(obj.body))}, nil
+}
+
+func (f *fakeS3) PutObject(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
+	body, err := io.ReadAll(params.Body)
+	if err != nil {
+		return nil, err
+	}
+	f.objects[*params.Key] = &fakeObject{
+		body:     body,
+		metadata: params.Metadata,
+		modified: f.clock,
+	}
+	f.clock = f.clock.Add(time.Second)
+	f.puts++
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (f *fakeS3) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	prefix := ""
+	if params.Prefix != nil {
+		prefix = *params.Prefix
+	}
+	var contents []types.Object
+	for key, obj := range f.objects {
+		if strings.HasPrefix(key, prefix) {
+			contents = append(contents, types.Object{
+				Key:          aws.String(key),
+				LastModified: aws.Time(obj.modified),
+			})
+		}
+	}
+	return &s3.ListObjectsV2Output{Contents: contents}, nil
+}
+
+func (f *fakeS3) DeleteObject(_ context.Context, params *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	delete(f.objects, *params.Key)
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+// staticDump returns a Dumper that always yields body.
+func staticDump(body []byte) Dumper {
+	return func(context.Context, DatabaseConfig) ([]byte, error) {
+		return body, nil
+	}
+}
+
+// failingDump returns a Dumper that always errors.
+func failingDump(err error) Dumper {
+	return func(context.Context, DatabaseConfig) ([]byte, error) {
+		return nil, err
+	}
+}
+
+// fixedClock returns a func usable as Handler.now.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}

--- a/backup/size.go
+++ b/backup/size.go
@@ -1,0 +1,18 @@
+package backup
+
+import "fmt"
+
+// HumanizeSize formats a byte count using binary units (KB/MB/GB/...), or
+// plain bytes below 1 KB. For example HumanizeSize(1572864) returns "1.50 MB".
+func HumanizeSize(b int) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := int64(b) / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/backup/size_test.go
+++ b/backup/size_test.go
@@ -1,0 +1,25 @@
+package backup
+
+import "testing"
+
+func TestHumanizeSize(t *testing.T) {
+	tests := []struct {
+		bytes int
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.00 KB"},
+		{1536, "1.50 KB"},
+		{1048576, "1.00 MB"},
+		{1572864, "1.50 MB"},
+		{1073741824, "1.00 GB"},
+		{5 * 1073741824, "5.00 GB"},
+	}
+	for _, tt := range tests {
+		if got := HumanizeSize(tt.bytes); got != tt.want {
+			t.Errorf("HumanizeSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+		}
+	}
+}

--- a/backup/store.go
+++ b/backup/store.go
@@ -1,0 +1,179 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// S3API is the subset of the AWS S3 client used by Handler. It is satisfied by
+// *s3.Client and allows the storage layer to be mocked in tests.
+type S3API interface {
+	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// checksum returns the hex-encoded SHA-256 of data.
+func checksum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// mostRecentBackup returns the key of the most recently modified object under
+// prefix, or "" when none exist.
+func (h *Handler) mostRecentBackup(ctx context.Context, prefix string) (string, error) {
+	resp, err := h.s3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(h.bucket),
+		Prefix: aws.String(prefix),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var mostRecent types.Object
+	var found bool
+	for _, obj := range resp.Contents {
+		if !found || obj.LastModified.After(*mostRecent.LastModified) {
+			mostRecent = obj
+			found = true
+		}
+	}
+	if found {
+		return *mostRecent.Key, nil
+	}
+	return "", nil
+}
+
+// objectChecksum returns the SHA-256 of the object at key, preferring the value
+// stored in object metadata and falling back to downloading and hashing the
+// body for objects written before checksums were recorded.
+func (h *Handler) objectChecksum(ctx context.Context, key string) (string, error) {
+	resp, err := h.s3.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(h.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if sum, ok := resp.Metadata["sha256"]; ok {
+		return sum, nil
+	}
+
+	getResp, err := h.s3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(h.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = getResp.Body.Close() }()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, getResp.Body); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// objectMatches reports whether the object at key exists and its checksum
+// equals the given checksum.
+func (h *Handler) objectMatches(ctx context.Context, key, sum string) bool {
+	existing, err := h.objectChecksum(ctx, key)
+	return err == nil && existing == sum
+}
+
+// upload writes data to key, recording its checksum in object metadata.
+func (h *Handler) upload(ctx context.Context, key string, data []byte, sum string) error {
+	_, err := h.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(h.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/sql"),
+		Metadata:    map[string]string{"sha256": sum},
+	})
+	return err
+}
+
+// objectExists reports whether key exists in the bucket.
+func (h *Handler) objectExists(ctx context.Context, key string) (bool, error) {
+	_, err := h.s3.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(h.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// uploadIfMissing writes data to key only when it does not already exist,
+// returning whether it created the object.
+func (h *Handler) uploadIfMissing(ctx context.Context, key string, data []byte, sum string) (bool, error) {
+	exists, err := h.objectExists(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("failed to check %s: %w", key, err)
+	}
+	if exists {
+		return false, nil
+	}
+	if err := h.upload(ctx, key, data, sum); err != nil {
+		return false, fmt.Errorf("failed to upload %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// cleanupOldDailyBackups deletes daily backups older than the retention window.
+// Keys are expected in the form "daily/YYYY-MM-DD-backup.sql"; unparseable keys
+// are left untouched.
+func (h *Handler) cleanupOldDailyBackups(ctx context.Context) error {
+	resp, err := h.s3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(h.bucket),
+		Prefix: aws.String("daily/"),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list daily backups: %w", err)
+	}
+
+	cutoff := h.now().AddDate(0, 0, -h.retentionDays)
+	for _, obj := range resp.Contents {
+		parts := strings.Split(*obj.Key, "/")
+		if len(parts) != 2 {
+			continue
+		}
+		datePart := strings.TrimSuffix(parts[1], "-backup.sql")
+		backupDate, err := time.Parse("2006-01-02", datePart)
+		if err != nil {
+			log.Printf("Warning: failed to parse date from key %s: %v", *obj.Key, err)
+			continue
+		}
+		if !backupDate.Before(cutoff) {
+			continue
+		}
+		if _, err := h.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(h.bucket),
+			Key:    obj.Key,
+		}); err != nil {
+			log.Printf("Warning: failed to delete old backup %s: %v", *obj.Key, err)
+		} else {
+			log.Printf("Deleted old daily backup: %s", *obj.Key)
+		}
+	}
+	return nil
+}

--- a/backup/store_test.go
+++ b/backup/store_test.go
@@ -1,0 +1,113 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestHandler(s3 S3API, retention int) *Handler {
+	h := New(Config{
+		S3:            s3,
+		Bucket:        "test-bucket",
+		Database:      DatabaseConfig{Host: "localhost"},
+		RetentionDays: retention,
+		Dump:          staticDump([]byte("dump")),
+	})
+	h.now = fixedClock(time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC))
+	return h
+}
+
+func TestObjectChecksumFromMetadata(t *testing.T) {
+	f := newFakeS3()
+	body := []byte("hello")
+	f.seed("daily/x.sql", body, time.Now())
+	h := newTestHandler(f, 7)
+
+	got, err := h.objectChecksum(context.Background(), "daily/x.sql")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != checksum(body) {
+		t.Errorf("objectChecksum = %q, want %q", got, checksum(body))
+	}
+}
+
+func TestObjectChecksumDownloadFallback(t *testing.T) {
+	f := newFakeS3()
+	body := []byte("no-metadata-body")
+	// Store without a sha256 metadata entry to force the download path.
+	f.objects["daily/y.sql"] = &fakeObject{body: body, metadata: map[string]string{}}
+	h := newTestHandler(f, 7)
+
+	got, err := h.objectChecksum(context.Background(), "daily/y.sql")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != checksum(body) {
+		t.Errorf("objectChecksum (download) = %q, want %q", got, checksum(body))
+	}
+}
+
+func TestObjectExists(t *testing.T) {
+	f := newFakeS3()
+	f.seed("daily/present.sql", []byte("x"), time.Now())
+	h := newTestHandler(f, 7)
+	ctx := context.Background()
+
+	if ok, err := h.objectExists(ctx, "daily/present.sql"); err != nil || !ok {
+		t.Errorf("present object: ok=%v err=%v, want ok=true err=nil", ok, err)
+	}
+	if ok, err := h.objectExists(ctx, "daily/absent.sql"); err != nil || ok {
+		t.Errorf("absent object: ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+}
+
+func TestObjectChecksumDownloadError(t *testing.T) {
+	f := newFakeS3()
+	// Object exists (Head succeeds) but has no sha256 metadata, and the
+	// download to compute it fails.
+	f.objects["daily/z.sql"] = &fakeObject{body: []byte("x"), metadata: map[string]string{}}
+	f.getErr = errors.New("download failed")
+	h := newTestHandler(f, 7)
+
+	if _, err := h.objectChecksum(context.Background(), "daily/z.sql"); err == nil {
+		t.Fatal("expected error from objectChecksum download, got nil")
+	}
+}
+
+func TestObjectExistsError(t *testing.T) {
+	f := newFakeS3()
+	f.headErr = errors.New("AccessDenied: nope")
+	h := newTestHandler(f, 7)
+
+	if _, err := h.objectExists(context.Background(), "daily/x.sql"); err == nil {
+		t.Fatal("expected error from objectExists, got nil")
+	}
+}
+
+func TestMostRecentBackup(t *testing.T) {
+	f := newFakeS3()
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	f.seed("daily/old.sql", []byte("a"), base)
+	f.seed("daily/new.sql", []byte("b"), base.Add(48*time.Hour))
+	f.seed("daily/mid.sql", []byte("c"), base.Add(24*time.Hour))
+	h := newTestHandler(f, 7)
+
+	got, err := h.mostRecentBackup(context.Background(), "daily/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "daily/new.sql" {
+		t.Errorf("mostRecentBackup = %q, want daily/new.sql", got)
+	}
+}
+
+func TestMostRecentBackupEmpty(t *testing.T) {
+	h := newTestHandler(newFakeS3(), 7)
+	got, err := h.mostRecentBackup(context.Background(), "daily/")
+	if err != nil || got != "" {
+		t.Errorf("empty bucket: got=%q err=%v, want empty/nil", got, err)
+	}
+}

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -1,574 +1,21 @@
+// Command lambda is the AWS Lambda entry point for go-postgres-s3-backup. It
+// wires environment configuration to the backup package and starts the Lambda
+// runtime; all backup logic lives in the importable backup package.
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/url"
 	"os"
-	"os/exec"
 	"strconv"
-	"strings"
-	"time"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/joho/godotenv"
+
+	"github.com/nicobistolfi/go-postgres-s3-backup/backup"
 )
-
-type BackupHandler struct {
-	s3Client *s3.Client
-	bucket   string
-	dbConfig DatabaseConfig
-}
-
-type DatabaseConfig struct {
-	Host     string
-	Port     string
-	User     string
-	Password string
-	Database string
-}
-
-// BackupResult summarizes a single backup run for the /run HTTP response.
-type BackupResult struct {
-	Status     string `json:"status"`      // always "ok" on success
-	Action     string `json:"action"`      // "created" or "skipped"
-	Reason     string `json:"reason"`      // why the daily backup was created/skipped
-	Key        string `json:"key"`         // today's daily backup S3 key
-	Size       string `json:"size"`        // human-readable dump size (e.g. "12.34 MB")
-	SizeBytes  int    `json:"size_bytes"`  // size of the dump in bytes
-	DurationMs int64  `json:"duration_ms"` // wall-clock time of the run
-}
-
-// humanizeSize formats a byte count using binary units (KB/MB/GB/...), or
-// plain bytes below 1 KB.
-func humanizeSize(b int) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := int64(b) / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.2f %cB", float64(b)/float64(div), "KMGTPE"[exp])
-}
-
-func NewBackupHandler() (*BackupHandler, error) {
-	// Load .env file for local development
-	_ = godotenv.Load()
-
-	// Initialize AWS config
-	cfg, err := config.LoadDefaultConfig(context.TODO())
-	if err != nil {
-		return nil, fmt.Errorf("unable to load SDK config: %w", err)
-	}
-
-	// Get environment variables
-	bucket := os.Getenv("BACKUP_BUCKET")
-	if bucket == "" {
-		return nil, fmt.Errorf("BACKUP_BUCKET environment variable not set")
-	}
-
-	dbConnStr := os.Getenv("DATABASE_URL")
-	if dbConnStr == "" {
-		return nil, fmt.Errorf("DATABASE_URL environment variable not set")
-	}
-
-	// Parse database URL
-	dbConfig, err := parseDatabaseURL(dbConnStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse DATABASE_URL: %w", err)
-	}
-
-	return &BackupHandler{
-		s3Client: s3.NewFromConfig(cfg),
-		bucket:   bucket,
-		dbConfig: dbConfig,
-	}, nil
-}
-
-func parseDatabaseURL(dbURL string) (DatabaseConfig, error) {
-	u, err := url.Parse(dbURL)
-	if err != nil {
-		return DatabaseConfig{}, err
-	}
-
-	password, _ := u.User.Password()
-
-	// Default port to 5432 if not specified
-	port := u.Port()
-	if port == "" {
-		port = "5432"
-	}
-
-	// Remove leading slash from path to get database name
-	database := strings.TrimPrefix(u.Path, "/")
-	if database == "" {
-		database = "postgres"
-	}
-
-	return DatabaseConfig{
-		Host:     u.Hostname(),
-		Port:     port,
-		User:     u.User.Username(),
-		Password: password,
-		Database: database,
-	}, nil
-}
-
-// HandleRequest runs a backup and returns a summary of what happened. When
-// force is true (manual /run invocation), the daily backup is always stored
-// even if its content matches the most recent daily backup; otherwise an
-// unchanged backup is skipped.
-func (h *BackupHandler) HandleRequest(ctx context.Context, force bool) (*BackupResult, error) {
-	start := time.Now()
-	log.Println("Starting database backup...")
-
-	// Create backup using pg_dump
-	backupData, err := h.createBackup(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create backup: %w", err)
-	}
-
-	// Get current date
-	now := time.Now()
-	year := now.Format("2006")
-	month := now.Format("2006-01")
-	day := now.Format("2006-01-02")
-
-	// Calculate checksum of the new backup
-	newChecksum := h.calculateChecksum(backupData)
-
-	// Find the most recent daily backup to compare against
-	mostRecentBackup, err := h.findMostRecentBackup(ctx, "daily/")
-	if err != nil {
-		log.Printf("Warning: couldn't find most recent backup: %v", err)
-	}
-
-	// Check if content has changed from the most recent backup
-	contentChanged := true
-	if mostRecentBackup != "" {
-		existingChecksum, err := h.getObjectChecksum(ctx, mostRecentBackup)
-		if err == nil && existingChecksum == newChecksum {
-			contentChanged = false
-		}
-	}
-
-	dailyKey := fmt.Sprintf("daily/%s-backup.sql", day)
-	result := &BackupResult{
-		Status:    "ok",
-		Key:       dailyKey,
-		Size:      humanizeSize(len(backupData)),
-		SizeBytes: len(backupData),
-	}
-
-	// Decide whether to write today's daily backup. A normal run stores it
-	// only when the dump differs from the most recent daily backup. A forced
-	// (manual) run stores it even when it matches an older backup, but still
-	// won't rewrite today's file when that file is already identical.
-	uploadDaily := contentChanged
-	result.Reason = "content changed"
-	if !contentChanged {
-		switch {
-		case !force:
-			result.Reason = "unchanged"
-		case h.objectMatches(ctx, dailyKey, newChecksum):
-			result.Reason = "today's backup already identical"
-		default:
-			uploadDaily = true
-			result.Reason = "forced; matched an older backup"
-		}
-	}
-
-	if !uploadDaily {
-		log.Printf("Skipping daily backup upload: %s", result.Reason)
-		result.Action = "skipped"
-		result.DurationMs = time.Since(start).Milliseconds()
-		return result, nil
-	}
-
-	if err := h.uploadToS3WithChecksum(ctx, dailyKey, backupData, newChecksum); err != nil {
-		return nil, fmt.Errorf("failed to upload daily backup: %w", err)
-	}
-	log.Printf("Daily backup uploaded: %s", dailyKey)
-	result.Action = "created"
-
-	// Create monthly/yearly backups if they don't exist yet.
-	// Check and create monthly backup if needed
-	monthlyKey := fmt.Sprintf("monthly/%s-backup.sql", month)
-	if exists, err := h.objectExists(ctx, monthlyKey); err != nil {
-		return nil, fmt.Errorf("failed to check monthly backup: %w", err)
-	} else if !exists {
-		if err := h.uploadToS3WithChecksum(ctx, monthlyKey, backupData, newChecksum); err != nil {
-			return nil, fmt.Errorf("failed to upload monthly backup: %w", err)
-		}
-		log.Printf("Monthly backup created: %s", monthlyKey)
-	}
-
-	// Check and create yearly backup if needed
-	yearlyKey := fmt.Sprintf("yearly/%s-backup.sql", year)
-	if exists, err := h.objectExists(ctx, yearlyKey); err != nil {
-		return nil, fmt.Errorf("failed to check yearly backup: %w", err)
-	} else if !exists {
-		if err := h.uploadToS3WithChecksum(ctx, yearlyKey, backupData, newChecksum); err != nil {
-			return nil, fmt.Errorf("failed to upload yearly backup: %w", err)
-		}
-		log.Printf("Yearly backup created: %s", yearlyKey)
-	}
-
-	// Clean up old daily backups (retention period from DAILY_BACKUP_RETENTION_DAYS env var, default 7 days)
-	if err := h.cleanupOldDailyBackups(ctx); err != nil {
-		log.Printf("Warning: failed to clean up old daily backups: %v", err)
-	}
-
-	log.Println("Backup process completed successfully")
-	result.DurationMs = time.Since(start).Milliseconds()
-	return result, nil
-}
-
-// objectMatches reports whether the object at key exists and its checksum
-// equals the given checksum.
-func (h *BackupHandler) objectMatches(ctx context.Context, key, checksum string) bool {
-	existing, err := h.getObjectChecksum(ctx, key)
-	return err == nil && existing == checksum
-}
-
-func (h *BackupHandler) createBackup(ctx context.Context) ([]byte, error) {
-	// Debug: Log current environment
-	log.Printf("Current PATH: %s", os.Getenv("PATH"))
-	log.Printf("Current LD_LIBRARY_PATH: %s", os.Getenv("LD_LIBRARY_PATH"))
-
-	// Set PATH to include layer binaries (note: layer creates /opt/opt/bin structure)
-	_ = os.Setenv("PATH", "/opt/opt/bin:"+os.Getenv("PATH"))
-
-	// Set library path for shared libraries
-	_ = os.Setenv("LD_LIBRARY_PATH", "/opt/opt/lib:"+os.Getenv("LD_LIBRARY_PATH"))
-
-	// Debug: Log updated environment
-	log.Printf("Updated PATH: %s", os.Getenv("PATH"))
-	log.Printf("Updated LD_LIBRARY_PATH: %s", os.Getenv("LD_LIBRARY_PATH"))
-
-	// Debug: Check what's in /opt
-	if entries, err := os.ReadDir("/opt"); err == nil {
-		log.Printf("Contents of /opt: %v", entries)
-		for _, entry := range entries {
-			if entry.IsDir() {
-				if subEntries, subErr := os.ReadDir("/opt/" + entry.Name()); subErr == nil {
-					log.Printf("Contents of /opt/%s: %v", entry.Name(), subEntries)
-				}
-			}
-		}
-	} else {
-		log.Printf("Error reading /opt directory: %v", err)
-	}
-
-	// Set PostgreSQL password via environment
-	_ = os.Setenv("PGPASSWORD", h.dbConfig.Password)
-
-	// Check if pg_dump binary exists
-	pgDumpPath := "/opt/opt/bin/pg_dump"
-	if _, err := os.Stat(pgDumpPath); os.IsNotExist(err) {
-		// Try to find it in PATH
-		var lookupErr error
-		pgDumpPath, lookupErr = exec.LookPath("pg_dump")
-		if lookupErr != nil {
-			return nil, fmt.Errorf("pg_dump binary not found in /opt/opt/bin or PATH: %w", lookupErr)
-		}
-	}
-
-	log.Printf("Using pg_dump at: %s", pgDumpPath)
-
-	// Build pg_dump command with full path
-	// Note: PostgreSQL 14 supports SCRAM auth and modern options
-	cmd := exec.CommandContext(ctx, pgDumpPath,
-		"-h", h.dbConfig.Host,
-		"-p", h.dbConfig.Port,
-		"-U", h.dbConfig.User,
-		"-d", h.dbConfig.Database,
-		"--verbose",
-		"--no-owner",
-		"--no-privileges",
-		"--clean",
-		"--if-exists",
-		"--exclude-schema=supabase_migrations",
-		"--no-comments",
-	)
-
-	// Capture output
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	// Run pg_dump
-	log.Println("Executing pg_dump...")
-	err := cmd.Run()
-
-	// Log stderr (pg_dump writes progress info to stderr)
-	if stderr.Len() > 0 {
-		log.Printf("pg_dump stderr: %s", stderr.String())
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("pg_dump failed: %w\nstderr: %s", err, stderr.String())
-	}
-
-	backupData := stdout.Bytes()
-
-	// Remove timestamp comments that cause unnecessary duplicates
-	backupData = h.removeTimestampComments(backupData)
-
-	log.Printf("Backup created successfully, size: %d bytes", len(backupData))
-
-	return backupData, nil
-}
-
-func (h *BackupHandler) removeTimestampComments(data []byte) []byte {
-	lines := bytes.Split(data, []byte("\n"))
-	var filtered [][]byte
-
-	for _, line := range lines {
-		// Skip lines that start with "-- Started on" or "-- Completed on"
-		if bytes.HasPrefix(line, []byte("-- Started on ")) ||
-			bytes.HasPrefix(line, []byte("-- Completed on ")) {
-			continue
-		}
-		filtered = append(filtered, line)
-	}
-
-	return bytes.Join(filtered, []byte("\n"))
-}
-
-func (h *BackupHandler) findMostRecentBackup(ctx context.Context, prefix string) (string, error) {
-	resp, err := h.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(h.bucket),
-		Prefix: aws.String(prefix),
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if len(resp.Contents) == 0 {
-		return "", nil
-	}
-
-	// Find the most recent backup by LastModified time
-	var mostRecent types.Object
-	var found bool
-	for _, obj := range resp.Contents {
-		if !found || obj.LastModified.After(*mostRecent.LastModified) {
-			mostRecent = obj
-			found = true
-		}
-	}
-
-	if found {
-		return *mostRecent.Key, nil
-	}
-
-	return "", nil
-}
-
-func (h *BackupHandler) calculateChecksum(data []byte) string {
-	hash := sha256.Sum256(data)
-	return hex.EncodeToString(hash[:])
-}
-
-func (h *BackupHandler) getObjectChecksum(ctx context.Context, key string) (string, error) {
-	// Try to get checksum from object metadata
-	resp, err := h.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(h.bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return "", err
-	}
-
-	// Check if we stored the checksum in metadata
-	if resp.Metadata != nil {
-		if checksum, ok := resp.Metadata["sha256"]; ok {
-			return checksum, nil
-		}
-	}
-
-	// If no checksum in metadata, we need to download and calculate
-	// This is for backwards compatibility with existing backups
-	getResp, err := h.s3Client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(h.bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = getResp.Body.Close() }()
-
-	hash := sha256.New()
-	if _, err := io.Copy(hash, getResp.Body); err != nil {
-		return "", err
-	}
-
-	return hex.EncodeToString(hash.Sum(nil)), nil
-}
-
-func (h *BackupHandler) uploadToS3WithChecksum(ctx context.Context, key string, data []byte, checksum string) error {
-	_, err := h.s3Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:      aws.String(h.bucket),
-		Key:         aws.String(key),
-		Body:        bytes.NewReader(data),
-		ContentType: aws.String("application/sql"),
-		Metadata: map[string]string{
-			"sha256": checksum,
-		},
-	})
-	return err
-}
-
-func (h *BackupHandler) objectExists(ctx context.Context, key string) (bool, error) {
-	_, err := h.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(h.bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		// Check if it's a "not found" error
-		if strings.Contains(err.Error(), "NotFound") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-func (h *BackupHandler) cleanupOldDailyBackups(ctx context.Context) error {
-	// List all daily backups
-	resp, err := h.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(h.bucket),
-		Prefix: aws.String("daily/"),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list daily backups: %w", err)
-	}
-
-	// Get retention days from environment variable, default to 7
-	retentionDays := 7
-	if retentionEnv := os.Getenv("DAILY_BACKUP_RETENTION_DAYS"); retentionEnv != "" {
-		if parsed, err := strconv.Atoi(retentionEnv); err == nil && parsed > 0 {
-			retentionDays = parsed
-			log.Printf("Using custom retention period: %d days", retentionDays)
-		} else {
-			log.Printf("Warning: Invalid DAILY_BACKUP_RETENTION_DAYS value '%s', using default 7 days", retentionEnv)
-		}
-	}
-
-	// Calculate cutoff date based on retention days
-	cutoff := time.Now().AddDate(0, 0, -retentionDays)
-
-	// Delete old backups
-	for _, obj := range resp.Contents {
-		// Extract date from key (format: daily/YYYY-MM-DD-backup.sql)
-		parts := strings.Split(*obj.Key, "/")
-		if len(parts) != 2 {
-			continue
-		}
-
-		datePart := strings.TrimSuffix(parts[1], "-backup.sql")
-		backupDate, err := time.Parse("2006-01-02", datePart)
-		if err != nil {
-			log.Printf("Warning: failed to parse date from key %s: %v", *obj.Key, err)
-			continue
-		}
-
-		if backupDate.Before(cutoff) {
-			_, err := h.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-				Bucket: aws.String(h.bucket),
-				Key:    obj.Key,
-			})
-			if err != nil {
-				log.Printf("Warning: failed to delete old backup %s: %v", *obj.Key, err)
-			} else {
-				log.Printf("Deleted old daily backup: %s", *obj.Key)
-			}
-		}
-	}
-
-	return nil
-}
-
-// dispatch routes the raw Lambda event to either the HTTP handler (when
-// invoked through the API Gateway /run endpoint) or the scheduled backup
-// handler (EventBridge cron or a direct/manual invoke).
-func (h *BackupHandler) dispatch(ctx context.Context, raw json.RawMessage) (any, error) {
-	var req events.APIGatewayV2HTTPRequest
-	if err := json.Unmarshal(raw, &req); err == nil && req.RequestContext.HTTP.Method != "" {
-		return h.handleHTTP(ctx, req), nil
-	}
-
-	// Scheduled or direct invocation: no HTTP response expected, dedupe applies.
-	_, err := h.HandleRequest(ctx, false)
-	return nil, err
-}
-
-// handleHTTP authenticates the API Gateway request, runs the backup, and
-// returns an HTTP response. It never returns an error so that auth/backup
-// failures surface as proper HTTP status codes rather than Lambda errors.
-func (h *BackupHandler) handleHTTP(ctx context.Context, req events.APIGatewayV2HTTPRequest) events.APIGatewayV2HTTPResponse {
-	if !authorized(req) {
-		return jsonResponse(401, map[string]string{"error": "unauthorized"})
-	}
-
-	// Manual runs always store a daily backup, even if content is unchanged.
-	result, err := h.HandleRequest(ctx, true)
-	if err != nil {
-		log.Printf("backup failed: %v", err)
-		return jsonResponse(500, map[string]string{"status": "error", "error": err.Error()})
-	}
-
-	return jsonResponse(200, result)
-}
-
-// authorized checks the request against the API_KEY env var. The key may be
-// supplied via the X-Api-Key header or the api_key query string parameter.
-func authorized(req events.APIGatewayV2HTTPRequest) bool {
-	expected := os.Getenv("API_KEY")
-	if expected == "" {
-		log.Println("API_KEY environment variable not set; rejecting request")
-		return false
-	}
-
-	// API Gateway v2 lower-cases header names.
-	if provided, ok := req.Headers["x-api-key"]; ok && constantTimeEqual(provided, expected) {
-		return true
-	}
-	if provided, ok := req.QueryStringParameters["api_key"]; ok && constantTimeEqual(provided, expected) {
-		return true
-	}
-
-	return false
-}
-
-func constantTimeEqual(a, b string) bool {
-	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
-}
-
-func jsonResponse(status int, body any) events.APIGatewayV2HTTPResponse {
-	b, _ := json.Marshal(body)
-	return events.APIGatewayV2HTTPResponse{
-		StatusCode: status,
-		Headers:    map[string]string{"Content-Type": "application/json"},
-		Body:       string(b),
-	}
-}
 
 // Build information, set via -ldflags at release time by GoReleaser.
 var (
@@ -580,10 +27,49 @@ var (
 func main() {
 	log.Printf("go-postgres-s3-backup %s (commit %s, built %s)", version, commit, date)
 
-	handler, err := NewBackupHandler()
+	// Load .env for local development.
+	_ = godotenv.Load()
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		log.Fatalf("Failed to initialize handler: %v", err)
+		log.Fatalf("unable to load SDK config: %v", err)
 	}
 
-	lambda.Start(handler.dispatch)
+	bucket := os.Getenv("BACKUP_BUCKET")
+	if bucket == "" {
+		log.Fatalf("BACKUP_BUCKET environment variable not set")
+	}
+
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		log.Fatalf("DATABASE_URL environment variable not set")
+	}
+	db, err := backup.ParseDatabaseURL(dbURL)
+	if err != nil {
+		log.Fatalf("failed to parse DATABASE_URL: %v", err)
+	}
+
+	handler := backup.New(backup.Config{
+		S3:            s3.NewFromConfig(cfg),
+		Bucket:        bucket,
+		Database:      db,
+		RetentionDays: retentionDays(),
+	})
+
+	events := backup.NewEventHandler(handler, os.Getenv("API_KEY"))
+	lambda.Start(events.Dispatch)
+}
+
+// retentionDays reads DAILY_BACKUP_RETENTION_DAYS, defaulting to 7 when unset
+// or invalid.
+func retentionDays() int {
+	v := os.Getenv("DAILY_BACKUP_RETENTION_DAYS")
+	if v == "" {
+		return 7
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return n
+	}
+	log.Printf("Warning: invalid DAILY_BACKUP_RETENTION_DAYS value %q, using default 7", v)
+	return 7
 }

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -570,7 +570,16 @@ func jsonResponse(status int, body any) events.APIGatewayV2HTTPResponse {
 	}
 }
 
+// Build information, set via -ldflags at release time by GoReleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	log.Printf("go-postgres-s3-backup %s (commit %s, built %s)", version, commit, date)
+
 	handler, err := NewBackupHandler()
 	if err != nil {
 		log.Fatalf("Failed to initialize handler: %v", err)


### PR DESCRIPTION
## Summary
Bring the repository up to [awesome-go](https://github.com/avelino/awesome-go) listing standards.

### Release pipeline (tag-triggered)
- `.github/workflows/release.yml` runs GoReleaser v2 on `v*` tags.
- `.goreleaser.yml` builds the `bootstrap` Lambda binary (linux arm64+amd64), injects version/commit/date, zips each target, and emits checksums + changelog. No Homebrew tap (Lambda, not a CLI).
- `cmd/lambda/main.go` logs version/commit/date at startup.
- Pushing a semver tag (e.g. `v1.0.0`) publishes a GitHub release → satisfies the "version-numbered release" requirement.

### Documented, testable package (was a single 580-line `package main`)
- New importable `backup/` package with **pkg.go.dev doc comments on all exported APIs** (`Config`, `Handler`, `New`, `Run`, `Result`, `DatabaseConfig`, `ParseDatabaseURL`, `HumanizeSize`, `PgDump`, `S3API`, `Dumper`, `EventHandler`, ...).
- `S3API` interface + injectable `Dumper` + injectable clock enable mocking; behavior unchanged (daily/monthly/yearly rotation, checksum dedupe, forced `/run`, retention cleanup).
- `cmd/lambda/main.go` reduced to thin wiring.

### Tests & coverage
- Table-driven + mock-based tests covering parsing, sizing, dedupe/force/skip paths, periodic creation, cleanup, HTTP auth, and dispatch.
- **~93% coverage** on the `backup` package; `golangci-lint` clean.
- CI uploads coverage to **Codecov**.

### Docs
- README badges (pkg.go.dev, Go Report Card, build, codecov, license), corrected stale claims (uses `pg_dump`, not pgx; Go 1.24+), and documented the package layout.

## Verification
- `go test ./...` green, ~93% coverage; `golangci-lint run` 0 issues; `go vet` / `gofmt` clean.
- `goreleaser check` valid; `goreleaser release --snapshot` produces zips + checksums.

## awesome-go status after this PR
| Requirement | Status |
|---|---|
| Repo age ≥ 5 months | ✅ ~10 months |
| SPDX license (MIT) | ✅ |
| README + pkg.go.dev docs | ✅ |
| Tests, coverage ≥ 80% | ✅ ~93% |
| `gofmt`/`vet`/lint clean, Go Report Card | ✅ (expect A) |
| go.mod at root | ✅ |
| Version-numbered release | ⏳ machinery ready — **push a `v1.0.0` tag** to publish |

Remaining manual steps (outside this repo): push the first tag, then open the one-line entry PR on avelino/awesome-go with pkg.go.dev / Go Report Card / coverage links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)