### PR TITLE
ci: fix quality-check card title and cancelled-run handling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -191,7 +191,7 @@ jobs:
     name: Quality Check Summary
     runs-on: ubuntu-latest
     needs: [check-label, build, test, lint, vulnerability-check]
-    if: always() && github.event_name == 'pull_request' && needs.check-label.outputs.should-run == 'true'
+    if: always() && !cancelled() && github.event_name == 'pull_request' && needs.check-label.outputs.should-run == 'true'
     steps:
       - name: Post Quality Check Results
         uses: actions/github-script@v7
@@ -206,7 +206,7 @@ jobs:
             // Find all bot comments with the quality check header
             const botComments = comments.filter(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('## 💎 Quality Check')
+              comment.body.includes('## 💎 Go PostgreSQL S3 Backup Quality Check')
             );
 
             // Delete all previous quality check comments
@@ -229,13 +229,15 @@ jobs:
 
             const requiredChecks = [buildStatus, testStatus, lintStatus, vulnStatus];
 
-            if (requiredChecks.some(status => status !== 'success')) {
+            // Only treat an actual 'failure' as a failed check; cancelled or
+            // skipped jobs should not produce a failure card.
+            if (requiredChecks.some(status => status === 'failure')) {
               statusEmoji = '❌';
               statusText = 'Some quality checks failed.';
             }
 
 
-            const body = `## 💎 Environment Manager Quality Check
+            const body = `## 💎 Go PostgreSQL S3 Backup Quality Check
 
             ${statusEmoji} **Status**: ${statusText}
 


### PR DESCRIPTION
## Summary
Fixes the misleading "Some quality checks failed" card that appeared on #10 when a run was cancelled (not failed), and renames the card to the project name.

### Changes
- **Rename** the summary card `Environment Manager Quality Check` → `Go PostgreSQL S3 Backup Quality Check` (leftover title from another project's template).
- **Fix the comment-dedup filter**: it searched for `## 💎 Quality Check`, which was *not* a substring of the actual header, so stale cards were never deleted. Now matches the real header.
- **Skip the summary on cancelled runs**: add `!cancelled()` to the job condition, so a run aborted by `concurrency: cancel-in-progress` no longer posts a card at all.
- **Only real failures fail the card**: the status logic now treats only a `failure` result as failed; `cancelled`/`skipped` no longer flip the card to ❌.

### Why the bad card appeared
A `labeled`-event run for the previous commit was cancelled by `cancel-in-progress` when the next commit was pushed seconds later. That cancelled run's `if: always()` summary job still fired and reported every job as `cancelled` → rendered as failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)