### PR TITLE
ci: run checks (and Codecov) on push to main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [check-label]
-    if: github.event_name == 'push' || needs.check-label.outputs.should-run == 'true'
+    if: always() && (github.event_name == 'push' || needs.check-label.outputs.should-run == 'true')
     strategy:
       matrix:
         go-version: ["1.25.10"]
@@ -139,7 +139,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: [check-label]
-    if: github.event_name == 'push' || needs.check-label.outputs.should-run == 'true'
+    if: always() && (github.event_name == 'push' || needs.check-label.outputs.should-run == 'true')
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem
Every recent `push` to `main` shows the **Build & Test** workflow as `skipped` — build, lint, test, and vulnerability-check all skip, so tests never run and **coverage is never uploaded to Codecov from `main`**.

### Root cause
`build` and `lint` declare `needs: [check-label]`, but `check-label` only runs on `pull_request` (`if: github.event_name == 'pull_request'`). On a push it's *skipped*, and GitHub cascades a skipped dependency to its dependents unless the dependent's condition uses `always()`. A plain boolean `if` (`github.event_name == 'push' || …`) does **not** override the cascade — so build/lint (and therefore test/vuln) skip on every push to `main`.

## Fix
Wrap the `build` and `lint` conditions in `always() && (...)`:

```yaml
if: always() && (github.event_name == 'push' || needs.check-label.outputs.should-run == 'true')
```

Now the skipped `check-label` no longer cascades.

## Behavior after fix
- **Push to `main`:** build → lint → test → vulnerability-check all run; **Codecov upload runs**. (quality-check-summary still only posts on PRs.)
- **PR with `run-checks` label:** unchanged — full suite runs.
- **PR without the label:** unchanged — jobs skip (label gating preserved).

YAML validated.

> Note: relies on the Codecov step from #10. Set the `CODECOV_TOKEN` repo secret for uploads to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)